### PR TITLE
Prefer jpeg-turbo over jpeg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
+language: generic
+
 os: osx
 osx_image: xcode9.2
+
 env:
   global:
     - COLUMNS=240
+
 before_install:
   - brew cleanup
-  - brew uninstall boost carthage cgal dirmngr freexl gdal go libgeotiff liblwgeom libspatialite maven mercurial postgis postgresql python sfcgal swiftlint
+  - brew uninstall boost carthage cgal dirmngr freexl gdal go libgeotiff liblwgeom libspatialite libtiff maven mercurial postgis postgresql python sfcgal swiftlint
   - brew update
   - brew upgrade
   - brew cleanup
+
 install:
   - brew install advancecomp
   - brew tap lovell/package-libvips-darwin https://github.com/lovell/package-libvips-darwin.git
+  - brew install lovell/package-libvips-darwin/libtiff --build-bottle
   - brew install lovell/package-libvips-darwin/gdk-pixbuf --build-bottle
   - brew postinstall lovell/package-libvips-darwin/gdk-pixbuf
   - brew install lovell/package-libvips-darwin/vips --build-bottle
+
 script:
-  - export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/local/opt/libffi/lib/pkgconfig"
+  - export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
   - ./package.sh
+
 addons:
   artifacts:
     s3_region: eu-west-1

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -5,9 +5,10 @@ class GdkPixbuf < Formula
   sha256 "f19ff836ba991031610dcc53774e8ca436160f7d981867c8c3a37acfe493ab3a"
 
   bottle do
-    sha256 "191484223e3008e91fef28edaac87fddaac10f65e4a061dda3d2e783deb9049e" => :mojave
-    sha256 "7213023a24faa8c847d742cb2c8994416abad45c6f9117274b04821e83df866a" => :high_sierra
-    sha256 "1ad9524a855f609809fc404b68afc6cb417b856921fec44b0710301a74289562" => :sierra
+    rebuild 1
+    sha256 "d1bb6279efd838ab42c7091e9454ad4eef8414bd88a2f2666d8f5e926ed34dcf" => :mojave
+    sha256 "6f87d84cd357f2cd7a85109da0b9edc070def6a15c7d77fe2093a1edae4a8379" => :high_sierra
+    sha256 "6cd83ebb309b5c1367eaba1cd20aa17ecea18aefa1065c8d9771d6a3c4844810" => :sierra
   end
 
   depends_on "gobject-introspection" => :build
@@ -64,13 +65,6 @@ class GdkPixbuf < Formula
       libv = s.get_make_var "gdk_pixbuf_binary_version"
       s.change_make_var! "gdk_pixbuf_binarydir",
         HOMEBREW_PREFIX/"lib/gdk-pixbuf-#{gdk_so_ver}"/libv
-    end
-
-    # fix gobject-introspection support
-    # will not be necessary after next release of gobject-introspection
-    %w[GdkPixbuf-2.0 GdkPixdata-2.0].each do |gir|
-      inreplace share/"gir-1.0/#{gir}.gir", "@rpath", lib.to_s
-      system "g-ir-compiler", "--includedir=#{share}/gir-1.0", "--output=#{lib}/girepository-1.0/#{gir}.typelib", share/"gir-1.0/#{gir}.gir"
     end
   end
 

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -16,7 +16,7 @@ class GdkPixbuf < Formula
   depends_on "pkg-config" => :build
   depends_on "python" => :build
   depends_on "glib"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
 
@@ -49,6 +49,8 @@ class GdkPixbuf < Formula
       -Dbuiltin_loaders=png,jpeg
     ]
 
+    ENV["LIBRARY_PATH"] = Formula["jpeg-turbo"].opt_lib
+    ENV["CPATH"] = Formula["jpeg-turbo"].opt_include
     ENV["DESTDIR"] = "/"
     mkdir "build" do
       system "meson", *args, ".."

--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -1,0 +1,56 @@
+class Libtiff < Formula
+  desc "TIFF library and utilities"
+  homepage "http://libtiff.maptools.org/"
+  url "https://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz"
+  mirror "https://fossies.org/linux/misc/tiff-4.0.10.tar.gz"
+  sha256 "2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"
+  revision 1
+
+  bottle do
+    cellar :any
+    sha256 "6ecdca6159e5e4db0ec0fcbddbc76dbdc65e496139b131a05f2a9ed8187914f8" => :mojave
+    sha256 "f05323c49236328f4a63e0acb9ff340baf37e589cf5699f334d1e98928f87fd4" => :high_sierra
+    sha256 "818a699c6a293cccfbae8c8b1d0320c0fd8f7ca17c711fded8764f36d11a3db6" => :sierra
+  end
+
+  depends_on "jpeg-turbo"
+
+  # Patches are taken from latest Fedora package, which is currently
+  # libtiff-4.0.10-2.fc30.src.rpm and whose changelog is available at
+  # https://apps.fedoraproject.org/packages/libtiff/changelog/
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/d15e00544e7df009b5ad34f3b65351fc249092c0/libtiff/libtiff-CVE-2019-6128.patch"
+    sha256 "dbec51f5bec722905288871e3d8aa3c41059a1ba322c1ac42ddc8d62646abc66"
+  end
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-lzma
+      --with-jpeg-include-dir=#{Formula["jpeg-turbo"].opt_include}
+      --with-jpeg-lib-dir=#{Formula["jpeg-turbo"].opt_lib}
+      --without-x
+    ]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <tiffio.h>
+
+      int main(int argc, char* argv[])
+      {
+        TIFF *out = TIFFOpen(argv[1], "w");
+        TIFFSetField(out, TIFFTAG_IMAGEWIDTH, (uint32) 10);
+        TIFFClose(out);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-ltiff", "-o", "test"
+    system "./test", "test.tif"
+    assert_match(/ImageWidth.*10/, shell_output("#{bin}/tiffdump test.tif"))
+  end
+end

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -16,7 +16,7 @@ class Vips < Formula
   depends_on "gettext"
   depends_on "giflib"
   depends_on "glib"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libexif"
   depends_on "libgsf"
   depends_on "libpng"

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -31,6 +31,8 @@ class Vips < Formula
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
+      --with-jpeg-includes=#{Formula["jpeg-turbo"].opt_include}
+      --with-jpeg-libraries=#{Formula["jpeg-turbo"].opt_lib}
     ]
 
     system "./configure", *args


### PR DESCRIPTION
It's 4x faster, better tested, and binary compatible. See the Homebrew discussion:
https://github.com/Homebrew/homebrew-core/pull/25682
https://github.com/Homebrew/homebrew-core/pull/25711

If you want, I can also change the `package.sh` build script (it should pack `jpeg-turbo` instead of `jpeg`).