### PR TITLE
Build releases with a GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,60 @@
+name: Build Release
+on:
+  push:
+    tags:
+    - v*
+jobs:
+  create-release:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Create Release
+      id: create-release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - shell: bash
+      run: |
+        echo '${{ steps.create-release.outputs.upload_url }}' > upload-url.txt
+    - name: Save GitHub release upload URL for next job
+      uses: actions/upload-artifact@v1
+      with:
+        name: upload-url
+        path: upload-url.txt
+  build:
+    runs-on: 'macos-latest'
+    needs:
+      - 'create-release'
+    env:
+      PKG_CONFIG_PATH: "/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+    steps:
+    - uses: actions/checkout@v1
+    - name: Fetch GitHub Release upload URL
+      uses: actions/download-artifact@v1
+      with:
+        name: upload-url
+    - name: Set up build environment
+      run: ./setup.sh
+    - name: Build
+      run: ./package.sh
+    - name: Clean up
+      run: ./cleanup.sh
+    - name: Set up environment variables
+      shell: bash
+      run: |
+        echo "::set-env name=upload_url::$(cat upload-url/upload-url.txt)"
+        echo "::set-env name=asset_file_name::libvips-$(pkg-config --modversion vips-cpp)-darwin-x64.tar.gz"
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.upload_url }}
+        asset_path: ${{ env.asset_file_name }}
+        asset_name: ${{ env.asset_file_name }}
+        asset_content_type: application/gzip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: 'macos-latest'
+    env:
+      PKG_CONFIG_PATH: "/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up build environment
+      run: ./setup.sh
+    - name: Build
+      run: ./package.sh
+    - name: Clean up
+      run: ./cleanup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,15 @@ env:
   global:
     - COLUMNS=240
     - PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
-    - HOMEBREW_NO_AUTO_UPDATE=1
-    - HOMEBREW_NO_INSTALL_CLEANUP=1
-    - KEEP_PACKAGES="cmake gdbm gettext giflib git jpeg libffi libpng libxml2 openssl openssl@1.1 pcre pkg-config python readline sqlite xz"
 
 before_install:
-  - brew cleanup
-  # Remove pre-installed Travis packages
-  # See: https://github.com/travis-ci/packer-templates-mac/blob/master/playbooks/roles/homebrew/defaults/main.yml
-  - brew list -1 | grep -Ev ${KEEP_PACKAGES// /|} | xargs brew rm -f
-  - brew update
-  - brew upgrade
-
-install:
-  - brew install advancecomp
-  - brew tap lovell/package-libvips-darwin https://github.com/lovell/package-libvips-darwin.git
-  - brew install lovell/package-libvips-darwin/libtiff --build-bottle
-  - brew install lovell/package-libvips-darwin/gdk-pixbuf --build-bottle
-  - brew postinstall lovell/package-libvips-darwin/gdk-pixbuf
-  - brew install lovell/package-libvips-darwin/vips --build-bottle
+  - ./setup.sh
 
 script:
   - ./package.sh
 
 before_cache:
-  - brew cleanup
+  - ./cleanup.sh
 
 cache:
   directories:

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+brew cleanup

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+HOMEBREW_NO_AUTO_UPDATE=1
+HOMEBREW_NO_INSTALL_CLEANUP=1
+KEEP_PACKAGES="cmake gdbm gettext giflib git jpeg libffi libpng libxml2 openssl openssl@1.1 pcre pkg-config python readline sqlite xz"
+PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+brew cleanup
+brew list -1 | grep -Ev ${KEEP_PACKAGES// /|} | xargs brew rm -f
+brew update
+brew upgrade
+
+brew install advancecomp
+brew tap lovell/package-libvips-darwin https://github.com/lovell/package-libvips-darwin.git
+brew install lovell/package-libvips-darwin/libtiff --build-bottle
+brew install lovell/package-libvips-darwin/gdk-pixbuf --build-bottle
+brew postinstall lovell/package-libvips-darwin/gdk-pixbuf
+brew install lovell/package-libvips-darwin/vips --build-bottle

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,6 @@ set -e
 HOMEBREW_NO_AUTO_UPDATE=1
 HOMEBREW_NO_INSTALL_CLEANUP=1
 KEEP_PACKAGES="cmake gdbm gettext giflib git jpeg libffi libpng libxml2 openssl openssl@1.1 pcre pkg-config python readline sqlite xz"
-PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 brew cleanup
 brew list -1 | grep -Ev ${KEEP_PACKAGES// /|} | xargs brew rm -f


### PR DESCRIPTION
Every time a new tag starting with `v*`, such as `v8.8.3` is being pushed, the "build-release" workflow will be triggered and do the following things:

* Create a release for the tag on GitHub
* Build libvips for Darwin
* Upload the release artifact to the GitHub release which was created before

This workflow makes the Travis CI build obsolete.