### PR TITLE
Upgrade to vips 8.9.0-rc3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,25 @@ env:
     - PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
     - HOMEBREW_NO_AUTO_UPDATE=1
     - HOMEBREW_NO_INSTALL_CLEANUP=1
-    - KEEP_PACKAGES="cmake gdbm gettext giflib git jpeg libffi libpng libxml2 openssl openssl@1.1 pcre pkg-config python readline sqlite xz"
 
 before_install:
-  - brew cleanup
-  # Remove pre-installed Travis packages
-  # See: https://github.com/travis-ci/packer-templates-mac/blob/master/playbooks/roles/homebrew/defaults/main.yml
-  - brew list -1 | grep -Ev ${KEEP_PACKAGES// /|} | xargs brew rm -f
+  - brew tap lovell/package-libvips-darwin https://github.com/lovell/package-libvips-darwin.git
+  - KEEP_DEPENDENCIES=$(brew deps --include-build lovell/package-libvips-darwin/vips)
+  - echo "$KEEP_DEPENDENCIES"
   - brew update
+  - brew cleanup
+  # Remove unused formulae to speed upgrade
+  - brew list -1 | grep -Ev ${KEEP_DEPENDENCIES//$'\n'/|} | xargs brew rm -f
+  # Ensure libtiff and gdk-pixbuf are also removed (for libjpeg-turbo support)
+  - brew rm -f libtiff gdk-pixbuf
   - brew upgrade
 
 install:
   - brew install advancecomp
-  - brew tap lovell/package-libvips-darwin https://github.com/lovell/package-libvips-darwin.git
-  - brew install lovell/package-libvips-darwin/libtiff --build-bottle
-  - brew install lovell/package-libvips-darwin/gdk-pixbuf --build-bottle
+  - brew install --build-bottle lovell/package-libvips-darwin/libtiff
+  - brew install --build-bottle lovell/package-libvips-darwin/gdk-pixbuf
   - brew postinstall lovell/package-libvips-darwin/gdk-pixbuf
-  - brew install lovell/package-libvips-darwin/vips --build-bottle
+  - brew install --build-bottle lovell/package-libvips-darwin/vips
 
 script:
   - ./package.sh

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -1,9 +1,8 @@
 class Vips < Formula
   desc "Image processing library"
   homepage "https://github.com/libvips/libvips"
-  url "https://github.com/libvips/libvips/releases/download/v8.8.4/vips-8.8.4.tar.gz"
-  sha256 "9f7ae87814d990b67913ae69dc5f26fe62719e29aa7e6cc8908066f31ee15a35"
-  revision 1
+  url "https://github.com/libvips/libvips/releases/download/v8.9.0-rc3/vips-8.9.0-rc3.tar.gz"
+  sha256 "1f14e93f24f1548fc3544c9496d4d94056663b2e505e94b9966171b4c0004b42"
 
   # This formula is compiled from source, so there are no bottles.
   bottle :unneeded

--- a/package.sh
+++ b/package.sh
@@ -66,7 +66,7 @@ printf "{\n\
   \"png\": \"$(pkg-config --modversion libpng)\",\n\
   \"svg\": \"$(pkg-config --modversion librsvg-2.0)\",\n\
   \"tiff\": \"$(pkg-config --modversion libtiff-4)\",\n\
-  \"vips\": \"$(pkg-config --modversion vips-cpp)\",\n\
+  \"vips\": \"$(pkg-config --modversion vips-cpp)-rc3\",\n\
   \"webp\": \"$(pkg-config --modversion libwebp)\",\n\
   \"xml\": \"$(pkg-config --modversion libxml-2.0)\"\n\
 }" >versions.json
@@ -74,7 +74,7 @@ printf "{\n\
 printf "\"darwin-x64\"" >platform.json
 
 # Generate tarball
-TARBALL=libvips-$(pkg-config --modversion vips-cpp)-darwin-x64.tar.gz
+TARBALL=libvips-$(pkg-config --modversion vips-cpp)-rc3-darwin-x64.tar.gz
 tar cfz "${TARBALL}" include lib *.json
 advdef --recompress --shrink-insane "${TARBALL}"
 


### PR DESCRIPTION
This PR updates libvips to 8.9.0-rc3 and improves the removal of unused formulae (by using `brew deps`).

Example build: https://travis-ci.org/kleisauke/libvips-packaging/builds/631031107.